### PR TITLE
fix(modal): resolve form validation issue in supplier modal

### DIFF
--- a/src/pages/Suppliers/components/SupplierModal.tsx
+++ b/src/pages/Suppliers/components/SupplierModal.tsx
@@ -52,8 +52,13 @@ const SupplierModal: React.FC<AddSupplierModalProps> = ({
     onClose();
   };
 
+  const handleClose = () => {
+    reset();
+    onClose();
+  };
+
   return (
-    <Dialog open={open} onClose={onClose}>
+    <Dialog open={open} onClose={handleClose}>
       <DialogTitle>
         {isEditing ? "Edit Supplier" : "Add New Supplier"}
       </DialogTitle>
@@ -102,7 +107,7 @@ const SupplierModal: React.FC<AddSupplierModalProps> = ({
           />
         </DialogContent>
         <DialogActions>
-          <Button onClick={onClose}>Cancel</Button>
+          <Button onClick={handleClose}>Cancel</Button>
           <Button type="submit" variant="contained">
             {isEditing ? "Update" : "Add"}
           </Button>


### PR DESCRIPTION
There was a small issue with the form validation errors displaying even when we close the suppliers modal.
It was fixed in this PR.